### PR TITLE
Add release workflow

### DIFF
--- a/.github/workflows/release-workflow.yml
+++ b/.github/workflows/release-workflow.yml
@@ -1,0 +1,35 @@
+name: Build and Release
+
+on:
+  release:
+    types: [created]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v3
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: "18"
+
+      - name: Install dependencies
+        run: npm install
+
+      - name: Run unit tests
+        run: npm test
+
+      - name: Build binaries
+        run: npm run build
+
+      - name: Upload release assets
+        uses: actions/upload-release-asset@v1
+        with:
+          upload_url: ${{ github.event.release.upload_url }}
+          asset_path: ./build/my-app.zip
+          asset_name: my-app.zip
+          asset_content_type: application/zip


### PR DESCRIPTION
# Add GitHub Actions workflow for build and release

## Description:

- Added a workflow that triggers on release creation.
- Checks out the repo, sets up Node.js 18, installs dependencies, runs unit tests, and builds the project.
- Uploads the built binaries as release assets.

This PR ensures that releases automatically build and package the app, reducing manual steps and improving release consistency.