### PR TITLE
Add GitHub Actions workflow for release-triggered testing and build

### DIFF
--- a/.github/workflows/release-workflow.yml
+++ b/.github/workflows/release-workflow.yml
@@ -1,0 +1,62 @@
+name: Test and Build on Release
+
+on:
+  release:
+    types: [created]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v3
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: "18"
+
+      - name: Install dependencies
+        run: npm install
+
+      - name: Run unit tests
+        run: npm test
+
+  build:
+    needs: test
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v3
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: "18"
+
+      - name: Install dependencies
+        run: npm install
+
+      - name: Install EAS CLI
+        run: npm install -g eas-cli
+
+      - name: Log in to Expo (EAS)
+        run: eas login --token ${{ secrets.EXPO_TOKEN }}
+
+      - name: Build Android binary
+        run: eas build --platform android --profile release --non-interactive
+
+      - name: Download built artifact
+        run: eas build:download --platform android --profile release --output app-android.apk
+
+      - name: Upload APK to GitHub Release
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ github.event.release.upload_url }}
+          asset_path: ./app-android.apk
+          asset_name: app-android.apk
+          asset_content_type: application/vnd.android.package-archive


### PR DESCRIPTION
This PR adds a new workflow file under .github/workflows/release-workflow.yml.
The workflow is triggered when a new GitHub release is created.
It runs unit tests, and if they pass, it builds the Expo binary and uploads it as a release asset.